### PR TITLE
add failing test for implicit join syntax

### DIFF
--- a/test/test-suite
+++ b/test/test-suite
@@ -1632,6 +1632,16 @@ class SqlTests(AbstractQTestCase):
         self.assertEquals(o[0], 'ppp dip.1@otherdomain.com')
         self.assertEquals(o[1], 'ppp dip.2@otherdomain.com')
 
+    def test_implicit_join_example(self):
+        cmd = '../bin/q "select myfiles.c8,emails.c2 from ../examples/exampledatafile myfiles, ../examples/group-emails-example emails where myfiles.c4 = emails.c1 and myfiles.c8 = \'ppp\'"'
+        retcode, o, e = run_command(cmd)
+
+        self.assertEquals(retcode, 0)
+        self.assertEquals(len(o), 2)
+
+        self.assertEquals(o[0], 'ppp dip.1@otherdomain.com')
+        self.assertEquals(o[1], 'ppp dip.2@otherdomain.com')
+
     def test_join_example_with_output_header(self):
         cmd = '../bin/q -O "select myfiles.c8 aaa,emails.c2 bbb from ../examples/exampledatafile myfiles join ../examples/group-emails-example emails on (myfiles.c4 = emails.c1) where myfiles.c8 = \'ppp\'"'
         retcode, o, e = run_command(cmd)


### PR DESCRIPTION
I didn't see any other references to this in the test suite or in issues. Apologies if it is a duplicate.

I'm curious if `q` is intended to cover implicit join syntax in addition to the explicit `JOIN` form. Examples I pulled from the test suite looks like this:

**explicit**
```
SELECT myfiles.c8, 
       emails.c2 
FROM   ../examples/exampledatafile myfiles 
JOIN   ../examples/GROUP-emails-example emails 
ON     (myfiles.c4 = emails.c1) 
WHERE  myfiles.c8 = 'ppp'
```

**implicit**
```
SELECT myfiles.c8, 
       emails.c2 
FROM   ../examples/exampledatafile myfiles, 
       ../examples/GROUP-emails-example emails 
WHERE  myfiles.c8 = 'ppp' 
AND    myfiles.c4 = emails.c1
```

the test I added is failing the exit code check, which matches my adhoc attempts. 
```
======================================================================
FAIL: test_implicit_join_example (__main__.SqlTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "./test-suite", line 1639, in test_implicit_join_example
    self.assertEquals(retcode, 0)
AssertionError: 1 != 0
```

The only reason I bring this up is I prefer the implicit form. 