### PR TITLE
Specify python2 as runtime

### DIFF
--- a/bin/q
+++ b/bin/q
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 #   Copyright (C) 2012-2014 Harel Ben-Attia
 #


### PR DESCRIPTION
More systems now have python 3 as their default python, which breaks ``q``.  (i.e. fixes #148)

This change enable ``q`` to keep working as intended. And follows "explicit is better than implicit" suggestion in "Zen of Python" :)