### PR TITLE
Add user definable functions aggregates and collations

### DIFF
--- a/bin/q
+++ b/bin/q
@@ -49,8 +49,15 @@ import hashlib
 import uuid
 import cStringIO
 import math
+import pkg_resources
+import logging
+import inspect
 
 DEBUG = False
+
+
+logger = logging.getLogger(__name__)
+
 
 def get_stdout_encoding(encoding_override=None):
     if encoding_override is not None and encoding_override != 'none':
@@ -118,11 +125,60 @@ class Sqlite3DB(object):
             str: 'TEXT', int: 'INT', long : 'INT' , float: 'FLOAT', None: 'TEXT'}
         self.numeric_column_types = set([int, long, float])
         self.add_user_functions()
+        self.add_entrypoints()
 
     def add_user_functions(self):
         self.conn.create_function("regexp", 2, regexp)
         self.conn.create_function("sha1", 1, sha1)
         self.conn.create_aggregate("percentile",2,StrictPercentile)
+
+    def _get_entrypoint_argument_count(self, entrypoint):
+        if isinstance(entrypoint, object):
+            return len(inspect.getargspec(entrypoint.step).args[1:])
+
+        return len(inspect.getargspec(entrypoint).args)
+
+    def add_entrypoints(self):
+        for entry_point in pkg_resources.iter_entry_points(group='q_functions'):
+            try:
+                loaded = entry_point.load()
+                self.conn.create_function(
+                    entry_point.name,
+                    self._get_entrypoint_argument_count(loaded),
+                    loaded,
+                )
+            except ImportError:
+                logger.warning(
+                    "Could not load entry point function: %s",
+                    entry_point,
+                )
+
+        for entry_point in pkg_resources.iter_entry_points(group='q_aggregates'):
+            try:
+                loaded = entry_point.load()
+                self.conn.create_aggregate(
+                    entry_point.name,
+                    self._get_entrypoint_argument_count(loaded),
+                    loaded,
+                )
+            except ImportError:
+                logger.warning(
+                    "Could not load entry point aggregate: %s",
+                    entry_point,
+                )
+
+        for entry_point in pkg_resources.iter_entry_points(group='q_collations'):
+            try:
+                loaded = entry_point.load()
+                self.conn.create_collation(
+                    entry_point.name,
+                    loaded,
+                )
+            except ImportError:
+                logger.warning(
+                    "Could not load entry point collations: %s",
+                    entry_point,
+                )
 
     def is_numeric_type(self, column_type):
         return column_type in self.numeric_column_types

--- a/bin/q
+++ b/bin/q
@@ -1798,6 +1798,9 @@ def run_standalone():
         print >> sys.stderr, "Max column length limit must be a positive integer (%s)" % max_column_length_limit
         sys.exit(31)
 
+    if options.verbose:
+        logging.basicConfig(level=logging.DEBUG)
+
     default_input_params = QInputParams(skip_header=options.skip_header,
         delimiter=options.delimiter,
         input_encoding=options.encoding,


### PR DESCRIPTION
### What does this do and why?

This adds new functionality allowing users to define and use custom aggregations, functions, and collations without requiring that those functions be included in the base `q` distribution by configuring `q` to find and register those using setuptools' 'Entry Points' system (available by default with all Python installations newer than 2.7.9).

###  Creating Custom Aggregates, Functions, or Collations

Given that I have a concrete example available for only one of the three possibilities below, I've leaned toward verbosity; apologies for the repetitiveness:

#### Creating a Custom Aggregate

To define a custom aggregate (example repository: https://github.com/coddingtonbear/q-stdev), just add a group `q_aggregates` to your project's `setup.py`:

```python
    ...
    entry_points={
        'q_aggregates': {
            'stdev = dot.path.to.module:Class'
        }
    }
    ...
```

The class referenced should meet the [requirements defined by Sqlite3's documentation for `create_aggregate`](https://docs.python.org/2/library/sqlite3.html#sqlite3.Connection.create_aggregate).  The argument count will be inferred by inspecting the referenced function's signature using `inspect`.

After defining your custom aggregate, you can use it in any query as a normal aggregation:

```sql
select stdev(some_field) from ./some_file.csv;
```


#### Creating a Custom Function

To define a custom function, add a group `q_functions` to your project's `setup.py`:

```python
    ...
    entry_points={
        'q_functions': {
            'md5_maybe = dot.path.to.module:function'
        }
    }
```

The function referenced should meet the [requirements defined by Sqlite3's documentation for
`create_function`](https://docs.python.org/2/library/sqlite3.html#sqlite3.Connection.create_function).   The argument count will be inferred by inspecting the referenced function's signature using `inspect`.

After defining your custom function, you can use it in any query as a normal function:

```sql
select md5_maybe(some_field) as some_field_md5 from ./some_file.csv;
```

#### Creating a Custom Collation

To define a custom function, add a group `q_collations` to your project's `setup.py`:

```python
    ...
    entry_points={
        'q_functions': {
            'reversed = dot.path.to.module:function'
        }
    }
```

The function referenced should meet the [requirements defined by Sqlite3's documentation for
`create_collation`](https://docs.python.org/2/library/sqlite3.html#sqlite3.Connection.create_collation).

After defining your custom collation, you can use it in any query as a normal collation:

```sql
select some_field from ./some_file.csv order by some_field collate reversed;
```

### Installing Custom Aggregates, Functions, or Collations

Just install the package providing the custom aggregation using whatever method you normally use for installing third-party packages.  This might be just running `pip install q-stdev`, or it might be running `python setup.py install` or `pip install .` from a package directory.

---

I think this'll be helpful for people like me who might have specific needs of running specialized calculations via `q` without needing to submit a patch upstream.

Cheers, and thank you for creating such a useful library that I use almost every single day.