### PR TITLE
Change link to ghbtns.com to prevent insecure content warning

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -27,7 +27,7 @@
       <h1 id="project_title">q</h1>
       <h2 id="project_tagline">q - Text as Data</h2>
 
-      <iframe src="http://ghbtns.com/github-btn.html?user=harelba&repo=q&type=watch&count=true&size=large"  allowtransparency="true" frameborder="0" scrolling="0" width="170" height="30"></iframe>
+      <iframe src="//ghbtns.com/github-btn.html?user=harelba&repo=q&type=watch&count=true&size=large"  allowtransparency="true" frameborder="0" scrolling="0" width="170" height="30"></iframe>
 
       <section id="downloads">
         <a class="zip_download_link" download href="https://github.com/harelba/q/archive/1.7.1.zip">Download the last stable version zip file </a>

--- a/contact.html
+++ b/contact.html
@@ -29,7 +29,7 @@
       <h2 id="project_tagline">q - Text as Data</h2>
 
 
-      <iframe src="http://ghbtns.com/github-btn.html?user=harelba&repo=q&type=watch&count=true&size=large"  allowtransparency="true" frameborder="0" scrolling="0" width="170" height="30"></iframe>
+      <iframe src="//ghbtns.com/github-btn.html?user=harelba&repo=q&type=watch&count=true&size=large"  allowtransparency="true" frameborder="0" scrolling="0" width="170" height="30"></iframe>
 
       <section id="downloads">
         <a class="zip_download_link" download href="https://github.com/harelba/q/archive/1.7.1.zip">Download the last stable version zip file </a>

--- a/examples.html
+++ b/examples.html
@@ -29,7 +29,7 @@
       <h2 id="project_tagline">q - Text as Data</h2>
 
 
-      <iframe src="http://ghbtns.com/github-btn.html?user=harelba&repo=q&type=watch&count=true&size=large"  allowtransparency="true" frameborder="0" scrolling="0" width="170" height="30"></iframe>
+      <iframe src="//ghbtns.com/github-btn.html?user=harelba&repo=q&type=watch&count=true&size=large"  allowtransparency="true" frameborder="0" scrolling="0" width="170" height="30"></iframe>
 
       <section id="downloads">
         <a class="zip_download_link" download href="https://github.com/harelba/q/archive/1.7.1.zip">Download the last stable version zip file </a>

--- a/future-ideas.html
+++ b/future-ideas.html
@@ -29,7 +29,7 @@
       <h2 id="project_tagline">q - Text as Data</h2>
 
 
-      <iframe src="http://ghbtns.com/github-btn.html?user=harelba&repo=q&type=watch&count=true&size=large"  allowtransparency="true" frameborder="0" scrolling="0" width="170" height="30"></iframe>
+      <iframe src="//ghbtns.com/github-btn.html?user=harelba&repo=q&type=watch&count=true&size=large"  allowtransparency="true" frameborder="0" scrolling="0" width="170" height="30"></iframe>
 
       <section id="downloads">
         <a class="zip_download_link" download href="https://github.com/harelba/q/archive/1.7.1.zip">Download the last stable version zip file </a>

--- a/implementation.html
+++ b/implementation.html
@@ -28,7 +28,7 @@
       <h2 id="project_tagline">q - Text as Data</h2>
 
 
-      <iframe src="http://ghbtns.com/github-btn.html?user=harelba&repo=q&type=watch&count=true&size=large"  allowtransparency="true" frameborder="0" scrolling="0" width="170" height="30"></iframe>
+      <iframe src="//ghbtns.com/github-btn.html?user=harelba&repo=q&type=watch&count=true&size=large"  allowtransparency="true" frameborder="0" scrolling="0" width="170" height="30"></iframe>
 
       <section id="downloads">
         <a class="zip_download_link" download href="https://github.com/harelba/q/archive/1.7.1.zip">Download the last stable version zip file </a>

--- a/index.html
+++ b/index.html
@@ -31,7 +31,7 @@
       <h2 id="project_tagline">q - Text as Data</h2>
 
 
-      <iframe src="http://ghbtns.com/github-btn.html?user=harelba&repo=q&type=watch&count=true&size=large"  allowtransparency="true" frameborder="0" scrolling="0" width="170" height="30"></iframe>
+      <iframe src="//ghbtns.com/github-btn.html?user=harelba&repo=q&type=watch&count=true&size=large"  allowtransparency="true" frameborder="0" scrolling="0" width="170" height="30"></iframe>
 
       <section id="downloads">
         <a class="zip_download_link" download href="https://github.com/harelba/q/archive/1.7.1.zip">Download the last stable version zip file </a>

--- a/install.html
+++ b/install.html
@@ -13,7 +13,7 @@
 </head>
 
 <body>
-  
+
   <!-- HEADER -->
   <div id="header_wrap" class="outer">
     <header class="inner" href="index.html">
@@ -28,7 +28,7 @@
       <h2 id="project_tagline">q - Text as Data</h2>
 
 
-      <iframe src="http://ghbtns.com/github-btn.html?user=harelba&repo=q&type=watch&count=true&size=large"  allowtransparency="true" frameborder="0" scrolling="0" width="170" height="30"></iframe>
+      <iframe src="//ghbtns.com/github-btn.html?user=harelba&repo=q&type=watch&count=true&size=large"  allowtransparency="true" frameborder="0" scrolling="0" width="170" height="30"></iframe>
 
       <section id="downloads">
         <a class="zip_download_link" download href="https://github.com/harelba/q/archive/1.7.1.zip">Download the last stable version zip file </a>

--- a/ja/contact.html
+++ b/ja/contact.html
@@ -29,7 +29,7 @@
       <h2 id="project_tagline">q - Text as Data</h2>
 
 
-      <iframe src="http://ghbtns.com/github-btn.html?user=harelba&repo=q&type=watch&count=true&size=large"  allowtransparency="true" frameborder="0" scrolling="0" width="170" height="30"></iframe>
+      <iframe src="//ghbtns.com/github-btn.html?user=harelba&repo=q&type=watch&count=true&size=large"  allowtransparency="true" frameborder="0" scrolling="0" width="170" height="30"></iframe>
 
       <section id="downloads">
         <a class="zip_download_link" download href="https://github.com/harelba/q/archive/1.6.3.zip">Download the last stable version zip file </a>

--- a/ja/examples.html
+++ b/ja/examples.html
@@ -29,7 +29,7 @@
       <h2 id="project_tagline">q - Text as Data</h2>
 
 
-      <iframe src="http://ghbtns.com/github-btn.html?user=harelba&repo=q&type=watch&count=true&size=large"  allowtransparency="true" frameborder="0" scrolling="0" width="170" height="30"></iframe>
+      <iframe src="//ghbtns.com/github-btn.html?user=harelba&repo=q&type=watch&count=true&size=large"  allowtransparency="true" frameborder="0" scrolling="0" width="170" height="30"></iframe>
 
       <section id="downloads">
         <a class="zip_download_link" download href="https://github.com/harelba/q/archive/1.6.3.zip">Download the last stable version zip file </a>

--- a/ja/future-ideas.html
+++ b/ja/future-ideas.html
@@ -29,7 +29,7 @@
       <h2 id="project_tagline">q - Text as Data</h2>
 
 
-      <iframe src="http://ghbtns.com/github-btn.html?user=harelba&repo=q&type=watch&count=true&size=large"  allowtransparency="true" frameborder="0" scrolling="0" width="170" height="30"></iframe>
+      <iframe src="//ghbtns.com/github-btn.html?user=harelba&repo=q&type=watch&count=true&size=large"  allowtransparency="true" frameborder="0" scrolling="0" width="170" height="30"></iframe>
 
       <section id="downloads">
         <a class="zip_download_link" download href="https://github.com/harelba/q/archive/1.6.3.zip">Download the last stable version zip file </a>

--- a/ja/implementation.html
+++ b/ja/implementation.html
@@ -28,7 +28,7 @@
       <h2 id="project_tagline">q - Text as Data</h2>
 
 
-      <iframe src="http://ghbtns.com/github-btn.html?user=harelba&repo=q&type=watch&count=true&size=large"  allowtransparency="true" frameborder="0" scrolling="0" width="170" height="30"></iframe>
+      <iframe src="//ghbtns.com/github-btn.html?user=harelba&repo=q&type=watch&count=true&size=large"  allowtransparency="true" frameborder="0" scrolling="0" width="170" height="30"></iframe>
 
       <section id="downloads">
         <a class="zip_download_link" download href="https://github.com/harelba/q/archive/1.6.3.zip">Download the last stable version zip file </a>

--- a/ja/index.html
+++ b/ja/index.html
@@ -31,7 +31,7 @@
       <h2 id="project_tagline">q - Text as Data</h2>
 
 
-      <iframe src="http://ghbtns.com/github-btn.html?user=harelba&repo=q&type=watch&count=true&size=large"  allowtransparency="true" frameborder="0" scrolling="0" width="170" height="30"></iframe>
+      <iframe src="//ghbtns.com/github-btn.html?user=harelba&repo=q&type=watch&count=true&size=large"  allowtransparency="true" frameborder="0" scrolling="0" width="170" height="30"></iframe>
 
       <section id="downloads">
         <a class="zip_download_link" download href="https://github.com/harelba/q/archive/1.6.3.zip">Download the last stable version zip file </a>

--- a/ja/install.html
+++ b/ja/install.html
@@ -28,7 +28,7 @@
       <h2 id="project_tagline">q - Text as Data</h2>
 
 
-      <iframe src="http://ghbtns.com/github-btn.html?user=harelba&repo=q&type=watch&count=true&size=large"  allowtransparency="true" frameborder="0" scrolling="0" width="170" height="30"></iframe>
+      <iframe src="//ghbtns.com/github-btn.html?user=harelba&repo=q&type=watch&count=true&size=large"  allowtransparency="true" frameborder="0" scrolling="0" width="170" height="30"></iframe>
 
       <section id="downloads">
         <a class="zip_download_link" download href="https://github.com/harelba/q/archive/1.6.3.zip">Download the last stable version zip file </a>

--- a/ja/limitations.html
+++ b/ja/limitations.html
@@ -29,7 +29,7 @@
       <h2 id="project_tagline">q - Text as Data</h2>
 
 
-      <iframe src="http://ghbtns.com/github-btn.html?user=harelba&repo=q&type=watch&count=true&size=large"  allowtransparency="true" frameborder="0" scrolling="0" width="170" height="30"></iframe>
+      <iframe src="//ghbtns.com/github-btn.html?user=harelba&repo=q&type=watch&count=true&size=large"  allowtransparency="true" frameborder="0" scrolling="0" width="170" height="30"></iframe>
 
       <section id="downloads">
         <a class="zip_download_link" download href="https://github.com/harelba/q/archive/1.6.3.zip">Download the last stable version zip file </a>

--- a/ja/rationale.html
+++ b/ja/rationale.html
@@ -28,7 +28,7 @@
       <h2 id="project_tagline">q - Text as Data</h2>
 
 
-      <iframe src="http://ghbtns.com/github-btn.html?user=harelba&repo=q&type=watch&count=true&size=large"  allowtransparency="true" frameborder="0" scrolling="0" width="170" height="30"></iframe>
+      <iframe src="//ghbtns.com/github-btn.html?user=harelba&repo=q&type=watch&count=true&size=large"  allowtransparency="true" frameborder="0" scrolling="0" width="170" height="30"></iframe>
 
       <section id="downloads">
         <a class="zip_download_link" download href="https://github.com/harelba/q/archive/1.6.3.zip">Download the last stable version zip file </a>

--- a/ja/requirements.html
+++ b/ja/requirements.html
@@ -28,7 +28,7 @@
       <h2 id="project_tagline">q - Text as Data</h2>
 
 
-      <iframe src="http://ghbtns.com/github-btn.html?user=harelba&repo=q&type=watch&count=true&size=large"  allowtransparency="true" frameborder="0" scrolling="0" width="170" height="30"></iframe>
+      <iframe src="//ghbtns.com/github-btn.html?user=harelba&repo=q&type=watch&count=true&size=large"  allowtransparency="true" frameborder="0" scrolling="0" width="170" height="30"></iframe>
 
       <section id="downloads">
         <a class="zip_download_link" download href="https://github.com/harelba/q/archive/1.6.3.zip">Download the last stable version zip file </a>

--- a/ja/tutorial.html
+++ b/ja/tutorial.html
@@ -28,7 +28,7 @@
       <h2 id="project_tagline">q - Text as Data</h2>
 
 
-      <iframe src="http://ghbtns.com/github-btn.html?user=harelba&repo=q&type=watch&count=true&size=large"  allowtransparency="true" frameborder="0" scrolling="0" width="170" height="30"></iframe>
+      <iframe src="//ghbtns.com/github-btn.html?user=harelba&repo=q&type=watch&count=true&size=large"  allowtransparency="true" frameborder="0" scrolling="0" width="170" height="30"></iframe>
 
       <section id="downloads">
         <a class="zip_download_link" download href="https://github.com/harelba/q/archive/1.6.3.zip">Download the last stable version zip file </a>

--- a/ja/usage.html
+++ b/ja/usage.html
@@ -28,7 +28,7 @@
       <h2 id="project_tagline">q - Text as Data</h2>
 
 
-      <iframe src="http://ghbtns.com/github-btn.html?user=harelba&repo=q&type=watch&count=true&size=large"  allowtransparency="true" frameborder="0" scrolling="0" width="170" height="30"></iframe>
+      <iframe src="//ghbtns.com/github-btn.html?user=harelba&repo=q&type=watch&count=true&size=large"  allowtransparency="true" frameborder="0" scrolling="0" width="170" height="30"></iframe>
 
       <section id="downloads">
         <a class="zip_download_link" download href="https://github.com/harelba/q/archive/1.6.3.zip">Download the last stable version zip file </a>

--- a/limitations.html
+++ b/limitations.html
@@ -29,7 +29,7 @@
       <h2 id="project_tagline">q - Text as Data</h2>
 
 
-      <iframe src="http://ghbtns.com/github-btn.html?user=harelba&repo=q&type=watch&count=true&size=large"  allowtransparency="true" frameborder="0" scrolling="0" width="170" height="30"></iframe>
+      <iframe src="//ghbtns.com/github-btn.html?user=harelba&repo=q&type=watch&count=true&size=large"  allowtransparency="true" frameborder="0" scrolling="0" width="170" height="30"></iframe>
 
       <section id="downloads">
         <a class="zip_download_link" download href="https://github.com/harelba/q/archive/1.7.1.zip">Download the last stable version zip file </a>

--- a/rationale.html
+++ b/rationale.html
@@ -28,7 +28,7 @@
       <h2 id="project_tagline">q - Text as Data</h2>
 
 
-      <iframe src="http://ghbtns.com/github-btn.html?user=harelba&repo=q&type=watch&count=true&size=large"  allowtransparency="true" frameborder="0" scrolling="0" width="170" height="30"></iframe>
+      <iframe src="//ghbtns.com/github-btn.html?user=harelba&repo=q&type=watch&count=true&size=large"  allowtransparency="true" frameborder="0" scrolling="0" width="170" height="30"></iframe>
 
       <section id="downloads">
         <a class="zip_download_link" download href="https://github.com/harelba/q/archive/1.7.1.zip">Download the last stable version zip file </a>

--- a/requirements.html
+++ b/requirements.html
@@ -28,7 +28,7 @@
       <h2 id="project_tagline">q - Text as Data</h2>
 
 
-      <iframe src="http://ghbtns.com/github-btn.html?user=harelba&repo=q&type=watch&count=true&size=large"  allowtransparency="true" frameborder="0" scrolling="0" width="170" height="30"></iframe>
+      <iframe src="//ghbtns.com/github-btn.html?user=harelba&repo=q&type=watch&count=true&size=large"  allowtransparency="true" frameborder="0" scrolling="0" width="170" height="30"></iframe>
 
       <section id="downloads">
         <a class="zip_download_link" download href="https://github.com/harelba/q/archive/1.7.1.zip">Download the last stable version zip file </a>

--- a/tutorial.html
+++ b/tutorial.html
@@ -28,7 +28,7 @@
       <h2 id="project_tagline">q - Text as Data</h2>
 
 
-      <iframe src="http://ghbtns.com/github-btn.html?user=harelba&repo=q&type=watch&count=true&size=large"  allowtransparency="true" frameborder="0" scrolling="0" width="170" height="30"></iframe>
+      <iframe src="//ghbtns.com/github-btn.html?user=harelba&repo=q&type=watch&count=true&size=large"  allowtransparency="true" frameborder="0" scrolling="0" width="170" height="30"></iframe>
 
       <section id="downloads">
         <a class="zip_download_link" download href="https://github.com/harelba/q/archive/1.7.1.zip">Download the last stable version zip file </a>

--- a/usage.html
+++ b/usage.html
@@ -28,7 +28,7 @@
       <h2 id="project_tagline">q - Text as Data</h2>
 
 
-      <iframe src="http://ghbtns.com/github-btn.html?user=harelba&repo=q&type=watch&count=true&size=large"  allowtransparency="true" frameborder="0" scrolling="0" width="170" height="30"></iframe>
+      <iframe src="//ghbtns.com/github-btn.html?user=harelba&repo=q&type=watch&count=true&size=large"  allowtransparency="true" frameborder="0" scrolling="0" width="170" height="30"></iframe>
 
       <section id="downloads">
         <a class="zip_download_link" download href="https://github.com/harelba/q/archive/1.7.1.zip">Download the last stable version zip file </a>


### PR DESCRIPTION
The document pages include an iframe with a `http` source for ghbtns.com

This PR aims to replace them with a protocol-less URI so they'll stop the insecure content warnings (and display properly)