### PR TITLE
Travis CI: Drop Python 2.6 and add Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: python
 python:
-  - "2.6"
   - "2.7"
+  - "3.6"
+matrix:
+  allow_failures:
+    - python: "3.6"
+install: pip install flake8
+before_script: flake8 ./bin/q --count --select=E901,E999,F821,F822,F823 --show-source --statistics
 script: test/test-all


### PR DESCRIPTION
Python 2.6 end of life was __more than five years ago__.  Also, let's start testing on Python 3 in __allow_failures__ mode so that we know where our tests are failing.  Add flake8 to the testing to look for syntax errors and undefined names.

__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree

