### PR TITLE
Fix missing leading zero

### DIFF
--- a/bin/q
+++ b/bin/q
@@ -509,6 +509,8 @@ class TableColumnInferer(object):
             value = value.strip()
         if value == '' or value is None:
             return None
+        if value[0] == '0' and len(value) > 1:
+            return str
 
         try:
             i = int(value)


### PR DESCRIPTION
```
echo $'01\n001\n0001' | python bin/q -c 1 "select * from -"
```

before:

```
1
1
1
```

after:

```
01
001
0001
```