### PR TITLE
determine mixed numeric types

### DIFF
--- a/bin/q
+++ b/bin/q
@@ -535,12 +535,15 @@ class TableColumnInferer(object):
             return type_list[0]
         else:
             # check for the number of types without nulls,
-            type_list_without_nulls = list(filter(
+            type_set_without_nulls = set(filter(
                 lambda x: x is not None, type_list))
             # If all the sample lines are of the same type,
-            if len(set(type_list_without_nulls)) == 1:
+            if len(type_set_without_nulls) == 1:
                 # return it
-                return type_list_without_nulls[0]
+                return list(type_set_without_nulls)[0]
+            # Check whether the sample lines are of mixed numeric type
+            elif type_set_without_nulls == {int, float}:
+                return float
             else:
                 return str
 

--- a/test/test-suite
+++ b/test/test-suite
@@ -2250,7 +2250,7 @@ class BasicModuleTests(AbstractQTestCase):
         self.assertTrue(q_output.error.msg.startswith('query error'))
 
     def test_execute_response(self):
-        tmpfile = self.create_file_with_data(six.b("a b c\n1 2 3\n4 5 6"))
+        tmpfile = self.create_file_with_data(six.b("a b c\n1 2 3\n4 5.0 6"))
 
         q = QTextAsData()
 
@@ -2272,7 +2272,7 @@ class BasicModuleTests(AbstractQTestCase):
         table_structure = metadata.table_structures[0]
 
         self.assertEqual(table_structure.column_names,[ 'a','b','c'])
-        self.assertEqual(table_structure.column_types,[ 'int','int','int'])
+        self.assertEqual(table_structure.column_types,[ 'int','float','int'])
         self.assertEqual(table_structure.filenames_str,tmpfile.name)
         self.assertTrue(len(table_structure.materialized_files.keys()),1)
         self.assertTrue(table_structure.materialized_files[tmpfile.name].filename,tmpfile.name)


### PR DESCRIPTION
when a column has mixed numeric types (`int` & `float`), it gets recognised as `text`. the patch addresses that.

before:

```sh
$ git checkout 2.0.2
$ echo '1 2\n3.0 4' | ./bin/q -A 'select * from -'
Table for file: stdin
  `c1` - text
  `c2` - int
```

after:

```
$ git checkout numeric
$ echo '1 2\n3.0 4' | ./bin/q -A 'select * from -'
Table for file: stdin
  `c1` - float
  `c2` - int
```