### PR TITLE
Remove brew install caution note

### DIFF
--- a/mkdocs/docs/index.md
+++ b/mkdocs/docs/index.md
@@ -32,7 +32,7 @@ Look at some examples [here](#examples), or just download the tool using the lin
 
 | Format | Instructions | Comments |
 :---|:---|:---|
-|[OSX](https://github.com/harelba/packages-for-q/raw/master/single-binary/Darwin/2.0.9/q)|Download the executable from the link on the left, make it executable, and use it.|`brew install q` currently downloads the older version `1.7.1`. I'll update it to install the new version soon||
+|[OSX](https://github.com/harelba/packages-for-q/raw/master/single-binary/Darwin/2.0.9/q)|Download the executable from the link on the left, make it executable, and use it.|`brew install q` works well too.||
 |[RPM Package](https://github.com/harelba/packages-for-q/raw/master/rpms/q-text-as-data-2.0.9-1.x86_64.rpm)| run `rpm -ivh <package-filename>` or `rpm -U <package-filename>` if you already have an older version of q.| A man page is available for this release. Just enter man q.|
 |[DEB Package](https://github.com/harelba/packages-for-q/raw/master/deb/q-text-as-data_2.0.9-2_amd64.deb)| Run `sudo dpkg -i <package-filename>`|A man page is available for this release. Just enter `man q`.|
 |[Windows Installer](https://github.com/harelba/packages-for-q/raw/master/windows/setup-q-2.0.9.exe)|Run the installer executable and hit next next next... q.exe will be added to the PATH so you can access it everywhere.|Windows doesn't update the PATH retroactively for open windows, so you'll need to open a new cmd window after the installation is done.|


### PR DESCRIPTION
brew install version is latest (2.0.10) now. Then I think we can remove caution note.

```
$ brew info q
q: stable 2.0.10, HEAD
Treat text as a database
https://github.com/harelba/q
Not installed
From: https://github.com/Homebrew/homebrew-core/blob/HEAD/Formula/q.rb
License: GPL-3.0
==> Options
--HEAD
        Install HEAD version
==> Analytics
install: 401 (30 days), 1,834 (90 days), 5,757 (365 days)
install-on-request: 389 (30 days), 1,727 (90 days), 5,489 (365 days)
build-error: 0 (30 days)
```