### PR TITLE
Require six >= 1.11.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     description="Run SQL directly on CSV or TSV files",
     author_email='harelba@gmail.com',
     install_requires=[
-        'six==1.11.0'
+        'six>=1.11.0'
     ],
     packages=[
         'bin'


### PR DESCRIPTION
It is not good practice pinning versions in `install_requires`, it should only define
minimal required versions.

See https://packaging.python.org/discussions/install-requires-vs-requirements/
> It is *not* considered best practice to use install_requires to pin dependencies to specific versions, or to specify sub-dependencies (i.e. dependencies of your dependencies). This is overly-restrictive, and prevents the user from gaining the benefit of dependency upgrades.