### PR TITLE
Add regex replace custom function

### DIFF
--- a/bin/q.py
+++ b/bin/q.py
@@ -102,6 +102,11 @@ def regexp(regular_expression, data):
     else:
         return False
 
+def resub(data,expression,replace):
+    if data is None:
+        return ""
+    return re.sub(expression,replace,data)
+
 def md5(data,encoding):
     m = hashlib.md5()
     m.update(six.text_type(data).encode(encoding))
@@ -211,6 +216,11 @@ user_functions = [
                     "Find regexp in string expression. Returns 1 if found or 0 if not",
                     regexp,
                     2),
+    UserFunctionDef(FunctionType.REGULAR,
+                    "resub","resub(<expr>,regex,replace) = <replaced-expr-string>",
+                    "Find and replace text",
+                    resub,
+                    3),
     UserFunctionDef(FunctionType.REGULAR,
                     "sha","sha(<expr>,<encoding>,<algorithm>) = <hex-string-of-sha>",
                     "Calculate sha of some expression. Algorithm can be one of 1,224,256,384,512. For now encoding must be manually provided. Will use the input encoding automatically in the future.",


### PR DESCRIPTION
This feature allows q to quickly get a new column based on a regex match of another column. And even execute a GROUP BY using this new column.

Example: Find the disk usage by extension for the current directory:

`du -sk *|grep "\."|q -b -t 'SELECT resub(c2,".*\.","") as ex,SUM(c1) FROM - GROUP BY ex ORDER BY SUM(c1)'`

This is quite nice compared to other answers in: https://unix.stackexchange.com/questions/308846/how-to-find-total-filesize-grouped-by-extension (Slightly modified for only looking in the current dir)

`find . -type f -depth 1 |  egrep -o "\.[a-zA-Z0-9]+$" | sort -u|xargs -I '%' find . -type f -name "*%" -depth 1 -exec du -ch {} + -exec echo % \;|egrep "^\.[a-zA-Z0-9]+$|total$"|uniq|paste - -`

```
find . -name '?*.*' -type f -depth 1 -print0 |                                                                                                                                                  
  perl -0ne '
    if (@s = stat$_){
      ($ext = $_) =~ s/.*\.//s;
      $s{$ext} += $s[12];
      $n{$ext}++;
    }
    END {
      for (sort{$s{$a} <=> $s{$b}} keys %s) {
        printf "%15d %4d %s\n",  $s{$_}<<9, $n{$_}, $_;
      }
    }'
```

Of course, it is possible to use q without this feature quite succinctly as well:

`du -sk *|grep "\."|sed 's/\t.*\.\(.*\)$/ \1/g'|q -b 'SELECT c2,SUM(c1) FROM - GROUP BY c2 ORDER BY SUM(c1)'`


However, as the capture groups become more complex, getting multiple captures from the same column, etc, I believe resub becomes much more useful.

As another example, I have already used this modified `q` to analyze a log file containing user agents, and creating a summary of the most used OS/DEVICE combination. (Simply group by both columns and count) This involved two extractions from the same field to acquire the OS and device.


Finally, resub gets to utilize the existing row and column parsing q has, this can be complicated if using sed (commas in quoted fields). 
