### PR TITLE
Replace equals sign in filename

### DIFF
--- a/bin/q.py
+++ b/bin/q.py
@@ -1370,7 +1370,7 @@ def normalize_filename_to_table_name(filename):
         filename = filename[:-7]
     elif filename.lower().endswith('.sqlite3'):
         filename = filename[:-8]
-    return filename.replace("-","_dash_").replace(".","_dot_").replace('?','_qm_').replace("/","_slash_").replace("\\","_backslash_").replace(":","_colon_").replace(" ","_space_").replace("+","_plus_")
+    return filename.replace("-","_dash_").replace(".","_dot_").replace('?','_qm_').replace("/","_slash_").replace("\\","_backslash_").replace(":","_colon_").replace(" ","_space_").replace("+","_plus_").replace("=","_equals_")
 
 def validate_content_signature(original_filename, source_signature,other_filename, content_signature,scope=None,dump=False):
     if dump:


### PR DESCRIPTION
When working with csv files in a folder that contains the equals sign "=", there is a failure. This change replaces the equal sign with the text.