### PR TITLE
fix(sec): upgrade urllib3 to 1.26.5

### DIFF
--- a/mkdocs/requirements.txt
+++ b/mkdocs/requirements.txt
@@ -24,5 +24,5 @@ pymdown-extensions==6.2.1
 requests==2.22.0
 six==1.14.0
 tornado==6.0.3
-urllib3==1.25.8
+urllib3==1.26.5
 wrapt==1.11.2


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in urllib3 1.25.8
- [CVE-2021-33503](https://www.oscs1024.com/hd/CVE-2021-33503)


### What did I do？
Upgrade urllib3 from 1.25.8 to 1.26.5 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS