### PR TITLE
docs: proposed change. edit example: replace "-d ," commandline flag …

### DIFF
--- a/mkdocs/docs/index.md
+++ b/mkdocs/docs/index.md
@@ -19,7 +19,7 @@ q allows the following:
     q "select c1,c5 from myfile.csv"
 
     # -d '|' sets the input delimiter, -H says there's a header
-    q -d , -H "select my_field from myfile.delimited-file-with-pipes"
+    q -d '|' -H "select my_field from myfile.delimited-file-with-pipes"
 
     # -C readwrite writes a cache for the csv file
     q -d , -H "select my_field from myfile.csv" -C readwrite


### PR DESCRIPTION
…with "-d '|'" for example related to pipe-separated-values file

I interpreted this filename (`myfile.delimited-file-with-pipes`) as a delimiter-separated-values file for which the delimiter is pipe ('|'). 

Given this section of the usage

```
    -p, --pipe-delimited
                        Same as -d '|'. Added for convenience and readability
```

I inferred that the line in the example should be 
```
q -d '|' -H "select my_field from myfile.delimited-file-with-pipes"
```
rather than 
```
q -d , -H "select my_field from myfile.delimited-file-with-pipes"
```