### PR TITLE
Fixing doc

### DIFF
--- a/mkdocs/docs/index.md
+++ b/mkdocs/docs/index.md
@@ -19,7 +19,7 @@ q allows the following:
     q "select c1,c5 from myfile.csv"
 
     # -d '|' sets the input delimiter, -H says there's a header
-    q -d , -H "select my_field from myfile.delimited-file-with-pipes"
+    q -d '|' -H "select my_field from myfile.delimited-file-with-pipes"
 
     # -C readwrite writes a cache for the csv file
     q -d , -H "select my_field from myfile.csv" -C readwrite


### PR DESCRIPTION
This is definetly an error in doc that I'm fixing.

Here is an example that shows that the text in current doc it not working:

```
bessarabov@bessarabov-osx:~$ q --version
q version 3.1.6
Python: 3.9.7 (default, Oct 18 2021, 00:59:13) // [Clang 13.0.0 ]
Copyright (C) 2012-2021 Harel Ben-Attia (harelba@gmail.com, @harelba on twitter)
http://harelba.github.io/q/

bessarabov@bessarabov-osx:~$ cat myfile.delimited-file-with-pipes
my_field|number
a|1
b|2
c|3
bessarabov@bessarabov-osx:~$ q -d , -H "select my_field from myfile.delimited-file-with-pipes"
query error: no such column: my_field
Warning - There seems to be a "no such column" error, and -H (header line) exists. Please make sure that you are using the column names from the header line and not the default (cXX) column names. Another issue might be that the file contains a BOM. Files that are encoded with UTF8 and contain a BOM can be read by specifying `-e utf-9-sig` in the command line. Support for non-UTF8 encoding will be provided in the future.
bessarabov@bessarabov-osx:~$
```

And here how my fixed doc work (using the same version of q and file):

```
bessarabov@bessarabov-osx:~$ q -d '|' -H "select my_field from myfile.delimited-file-with-pipes"
a
b
c
bessarabov@bessarabov-osx:~$
```