### PR TITLE
q.py: Use timezone-aware objects to represent datetimes in UTC

### DIFF
--- a/bin/q.py
+++ b/bin/q.py
@@ -1663,7 +1663,7 @@ class MaterializedDelimitedFileState(MaterializedState):
         xprint("after perform_analyze")
         self.content_signature = table_creator._generate_content_signature()
 
-        now = datetime.datetime.utcnow().isoformat()
+        now = datetime.datetime.now(datetime.UTC)
 
         database_info.sqlite_db.add_to_qcatalog_table(target_sqlite_table_name,
                                           self.content_signature,


### PR DESCRIPTION
q.py:1624: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
  now = datetime.datetime.utcnow().isoformat()

Python 3,12